### PR TITLE
fix latest discord var changes

### DIFF
--- a/base.css
+++ b/base.css
@@ -4,6 +4,11 @@
     --font-primary: 'Rajdhani';
     --primary-text-color: lightgray;
 
+    --background-gradient-chat: black;
+    --background-gradient-app-frame: var(--dark-primary-color);
+    --custom-theme-base-color: var(--primary-color);
+    --custom-theme-base-color-amount: 0;
+
     --primary: 23, 13, 22;
     --red: 255, 0, 60;
     --blue: 114, 234, 248;


### PR DESCRIPTION
After the latest changes to styling Discord introduced new variables which are not covered by the current version of the theme. See below for the comparison of before and after. Happy to move vars around if need be.

<details>
  <summary>Before my changes (current)</summary>
<img width="2483" height="1389" alt="image" src="https://github.com/user-attachments/assets/5446ea42-c6fb-4931-96f2-fd4699501769" />
<img width="2315" height="1373" alt="image" src="https://github.com/user-attachments/assets/190d7913-443f-4b1a-91ad-58d8877485d2" />
</details>

<details>
  <summary>After my changes</summary>
<img width="2479" height="1396" alt="image" src="https://github.com/user-attachments/assets/fc26c2f3-8065-4161-bb26-9ba9c03d28cd" />
<img width="1853" height="1385" alt="image" src="https://github.com/user-attachments/assets/98b645ed-3f57-452e-813b-e502deb6efd8" />
</details>


